### PR TITLE
upload zipped post body

### DIFF
--- a/Classes/SaveRequest.m
+++ b/Classes/SaveRequest.m
@@ -42,7 +42,6 @@
 #import "SaveRequest.h"
 #import "ZipUtil.h"
 
-
 @implementation SaveRequest
 
 @synthesize request, deviceUniqueIdHash, postVars;
@@ -62,9 +61,6 @@
         [request setURL:[NSURL URLWithString:kSaveURL]];
         [request setHTTPMethod:@"POST"];
         [request setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
-//        [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
-//        [request setValue:@"chunked" forHTTPHeaderField:@"Transfer-Encoding"];
-//        [request setValue:@"multipart/form-data" forHTTPHeaderField:@"Content-Type"];
 		
         self.postVars = [NSMutableDictionary dictionaryWithDictionary:inPostVars];
         NSLog(@"postVars = %@", postVars);
@@ -75,19 +71,24 @@
         //convert dict to string
 		NSMutableString *postBody = [NSMutableString string];
     
-		for(NSString * key in postVars)
-			[postBody appendString:[NSString stringWithFormat:@"%@=%@&", key, [postVars objectForKey:key]]];
+        NSString *sep = @"";
+		for(NSString * key in postVars) {
+			[postBody appendString:[NSString stringWithFormat:@"%@%@=%@",
+                                    sep,
+                                    key,
+                                    [postVars objectForKey:key]]];
+            sep = @"&";
+        }
         
-        //gzip the POST payload
-        //NSData *postBodyData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
-        //NSData *postBodyDataZipped = [ZipUtil gzipDeflate:postBodyData];
+        // gzip the POST payload
+        NSData *originalData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
+        NSData *postBodyDataZipped = [ZipUtil gzipDeflate:originalData];
         
-		NSLog(@"Initializing HTTP POST request to %@ of size %d with body %@", 
-			  kSaveURL, [[postBody dataUsingEncoding:NSUTF8StringEncoding] length], postBody);
+		NSLog(@"Initializing HTTP POST request to %@ of size %d, orig size %d",
+			  kSaveURL, [postBodyDataZipped length], [originalData length]);
 
         //set the POST body
-		[request setHTTPBody:[postBody dataUsingEncoding:NSUTF8StringEncoding]];
-        //[request setHTTPBody:postBodyDataZipped];
+        [request setHTTPBody:postBodyDataZipped];
 
 	}
 	

--- a/Classes/SaveRequest.m
+++ b/Classes/SaveRequest.m
@@ -60,8 +60,14 @@
         self.request = [[NSMutableURLRequest alloc] init];
         [request setURL:[NSURL URLWithString:kSaveURL]];
         [request setHTTPMethod:@"POST"];
+        [request setValue:@"3" forHTTPHeaderField:@"Cycleatl-Protocol-Version"];
         [request setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
-		
+        
+        // this is a bit grotty, but it indicates a) cycleatl namespace
+        // b) trip upload, c) version 3, d) form encoding
+        [request setValue:@"application/vnd.cycleatl.trip-v3+form"
+                 forHTTPHeaderField:@"Content-Type"];
+        
         self.postVars = [NSMutableDictionary dictionaryWithDictionary:inPostVars];
         NSLog(@"postVars = %@", postVars);
 	


### PR DESCRIPTION
I'm pretty sure this is generating a correct request.  Using HTTPScoop on my Mac, I see the correct POST body uncompressed, but with ngrep I see a compressed body. That leads me to believe that HTTPScoop is detecting compression from the Content-Encoding header and decompressing it for my viewing pleasure, and that the compression is therefore correct.

![Screen Shot 2013-01-29 at 12 54 48 PM](https://f.cloud.github.com/assets/6990/107942/4b5416fa-6a3d-11e2-9d4e-cbb613a4fc7c.png)

![Screen Shot 2013-01-29 at 12 54 57 PM](https://f.cloud.github.com/assets/6990/107943/4f66a898-6a3d-11e2-967b-1f3206e1aa81.png)

![Screen Shot 2013-01-29 at 12 55 28 PM](https://f.cloud.github.com/assets/6990/107944/527c8b24-6a3d-11e2-9dd6-d43100462115.png)
